### PR TITLE
Update color and typography list

### DIFF
--- a/components/01-atoms/01-colors/colors.config.yml
+++ b/components/01-atoms/01-colors/colors.config.yml
@@ -16,6 +16,16 @@ context:
           color: "#9bdaf1"
         - label: color-primary-alt-lightest
           color: "#e1f3f8"
+        - label: color-secondary
+          color: "#e31c3d"
+        - label: color-secondary-dark
+          color: "#cd2026"
+        - label: color-secondary-darkest
+          color: "#981b1e"
+        - label: color-secondary-light
+          color: "#e59393"
+        - label: color-secondary-lightest
+          color: "#f9dede"
         - label: color-white
           color: "#ffffff"
         - label: color-black
@@ -26,12 +36,18 @@ context:
           color: "#323a45"
         - label: color-gray
           color: "#5b616b"
+        - label: color-gray-medium
+          color: "#757575"
         - label: color-gray-light
           color: "#aeb0b5"
         - label: color-gray-lighter
           color: "#d6d7d9"
         - label: color-gray-lightest
           color: "#f1f1f1"
+        - label: color-gold
+          color: "#fdb81e"
+        - label: color-gold-lightest
+          color: "#fff1d2"
         - label: color-green
           color: "#2e8540"
         - label: color-green-light

--- a/components/01-atoms/01-colors/colors.config.yml
+++ b/components/01-atoms/01-colors/colors.config.yml
@@ -16,16 +16,6 @@ context:
           color: "#9bdaf1"
         - label: color-aqua-lightest
           color: "#e1f3f8"
-        - label: color-red
-          color: "#e31c3d"
-        - label: color-red-dark
-          color: "#cd2026"
-        - label: color-red-darkest
-          color: "#981b1e"
-        - label: color-red-light
-          color: "#e59393"
-        - label: color-red-lightest
-          color: "#f9dede"
         - label: color-white
           color: "#ffffff"
         - label: color-black
@@ -36,28 +26,12 @@ context:
           color: "#323a45"
         - label: color-gray
           color: "#5b616b"
-        - label: color-gray-medium
-          color: "#757575"
         - label: color-gray-light
           color: "#aeb0b5"
         - label: color-gray-lighter
           color: "#d6d7d9"
         - label: color-gray-lightest
           color: "#f1f1f1"
-        - label: color-gray-warm-dark
-          color: "#494440"
-        - label: color-gray-warm-light
-          color: "#e4e2e0"
-        - label: color-gray-cool-light
-          color: "#dce4ef"
-        - label: color-gold
-          color: "#fdb81e"
-        - label: color-gold-light
-          color: "#f9c642"
-        - label: color-gold-lighter
-          color: "#fad980"
-        - label: color-gold-lightest
-          color: "#fff1d2"
         - label: color-green
           color: "#2e8540"
         - label: color-green-light
@@ -66,13 +40,5 @@ context:
           color: "#94bfa2"
         - label: color-green-lightest
           color: "#e7f4e4"      
-        - label: color-cool-blue
-          color: "#205493"
-        - label: color-cool-blue-light
-          color: "#4773aa"
-        - label: color-cool-blue-lighter
-          color: "#8ba6ca"
-        - label: color-cool-blue-lightest
-          color: "#dce4ef"
         - label: color-purple
           color: "#4c2c92"

--- a/components/01-atoms/01-colors/colors.config.yml
+++ b/components/01-atoms/01-colors/colors.config.yml
@@ -1,26 +1,26 @@
 context: 
     colorset:
-        - label: color-blue
+        - label: color-primary
           color: "#0071bc"
-        - label: color-blue-darker
+        - label: color-primary-darker
           color: "#205493"
-        - label: color-blue-darkest
+        - label: color-primary-darkest
           color: "#112e51"
-        - label: color-aqua
+        - label: color-primary-alt
           color: "#02bfe7"
-        - label: color-aqua-dark
+        - label: color-primary-alt-dark
           color: "#00a6d2"
-        - label: color-aqua-darkest
+        - label: color-primary-alt-darkest
           color: "#046b99"
-        - label: color-aqua-light
+        - label: color-primary-alt-light
           color: "#9bdaf1"
-        - label: color-aqua-lightest
+        - label: color-primary-alt-lightest
           color: "#e1f3f8"
         - label: color-white
           color: "#ffffff"
         - label: color-black
           color: "#000000"
-        - label: color-black-light
+        - label: color-base
           color: "#212121"
         - label: color-gray-dark
           color: "#323a45"
@@ -40,5 +40,5 @@ context:
           color: "#94bfa2"
         - label: color-green-lightest
           color: "#e7f4e4"      
-        - label: color-purple
+        - label: color-visited
           color: "#4c2c92"

--- a/components/01-atoms/02-typography/fonts.config.yml
+++ b/components/01-atoms/02-typography/fonts.config.yml
@@ -20,19 +20,3 @@ context:
             and thick weights gives the font family stylistic range, while conveying a desirable
             mix of classic, yet modern simplicity. Merriweather communicates warmth and credibility
             at both large and smaller font sizes.'
-        - id: open-sans
-          name: Open Sans
-          description: Praesent egestas neque eu enim. Phasellus consectetuer vestibulum elit.
-            Nullam quis ante. Fusce commodo aliquam arcu. Praesent egestas neque eu enim.
-            Phasellus consectetuer vestibulum elit. Nullam quis ante. Fusce commodo aliquam
-            arcu.Praesent egestas neque eu enim. Phasellus consectetuer vestibulum elit. Nullam
-            quis ante. Fusce commodo aliquam arcu.
-        - id: montserrat
-          name: Montserrat
-          description: Praesent egestas neque eu enim. Phasellus consectetuer vestibulum elit.
-            Nullam quis ante. Fusce commodo aliquam arcu. Praesent egestas neque eu enim.
-            Phasellus consectetuer vestibulum elit. Nullam quis ante. Fusce commodo aliquam
-            arcu. Praesent egestas neque eu enim. Phasellus consectetuer vestibulum elit.
-            Nullam quis ante. Fusce commodo aliquam arcu. Praesent egestas neque eu enim.
-            Phasellus consectetuer vestibulum elit. Nullam quis ante. Fusce commodo aliquam
-            arcu.

--- a/components/01-atoms/02-typography/heading.twig
+++ b/components/01-atoms/02-typography/heading.twig
@@ -2,7 +2,5 @@
 <h2>{{ h2 }}</h2>
 <h3>{{ h3 }}</h3>
 <h4>{{ h4 }}</h4>
-<h5>{{ h5 }}</h5>
-<h6>{{ h6 }}</h6>
 
 <h2 class="sfgov-header-section">{{ title }}</h2>

--- a/components/02-molecules/10-person/10-person-section-display-hero.scss
+++ b/components/02-molecules/10-person/10-person-section-display-hero.scss
@@ -32,7 +32,7 @@
         font-weight: bold;
         a {
           text-decoration: none;
-          color: $color-blue;
+          color: $color-primary;
           > * {
             display: inline-block;
             text-decoration: none;

--- a/components/02-molecules/10-person/10-person-section-display.scss
+++ b/components/02-molecules/10-person/10-person-section-display.scss
@@ -28,7 +28,7 @@
     .person-name {
       a {
         text-decoration: underline;
-        color: $color-blue;
+        color: $color-primary;
         > * {
           display: inline-block;
           text-decoration: underline;

--- a/components/03-organisms/01-header/header.twig
+++ b/components/03-organisms/01-header/header.twig
@@ -6,10 +6,6 @@
       <div class="head-right--container">
         {{ translate_block }}
       </div>
-      {% if pl_test_content %}
-        {% include 'branding' %}
-        {% include 'main-navigation' %}
-      {% endif %}
     </div>
   </div>
 </header>

--- a/components/_preview.twig
+++ b/components/_preview.twig
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/fontawesome.css" integrity="sha384-GVa9GOgVQgOk+TNYXu7S/InPTfSDTtBalSgkgqQ7sCik56N9ztlkoTr2f/T44oKV" crossorigin="anonymous">
     {# todo: check if fonts are going to be selfhosted or not. #}
     <link rel="stylesheet"
-          href="//fonts.googleapis.com/css?family=Merriweather:400,700|Montserrat|Open+Sans|Source+Sans+Pro:400,700"
+          href="//fonts.googleapis.com/css?family=Merriweather:400,700|Source+Sans+Pro:400,700"
           media="all"/>
     <script src="/js/uswds.min.js"></script>
 </head>

--- a/public/css/core/_mixins.scss
+++ b/public/css/core/_mixins.scss
@@ -110,18 +110,6 @@
   font-weight: $font-bold;
 }
 
-@mixin h5 {
-  font-size: $h5-font-size;
-  font-weight: $font-bold;
-}
-
-@mixin h6 {
-  font-size: $h6-font-size;
-  font-weight: $font-normal;
-  line-height: $base-line-height;
-  text-transform: uppercase;
-}
-
 // Focus state mixin
 @mixin focus {
   outline: $focus-outline;

--- a/public/css/core/_mixins.scss
+++ b/public/css/core/_mixins.scss
@@ -71,14 +71,6 @@
   font-family: "Merriweather", sans-serif;
 }
 
-@mixin open-sans {
-  font-family: "Open Sans", sans-serif;
-}
-
-@mixin montserrat {
-  font-family: "Montserrat", sans-serif;
-}
-
 // Heading mixins
 @mixin title {
   font-size: $title-font-size;

--- a/public/css/core/_variables.scss
+++ b/public/css/core/_variables.scss
@@ -42,12 +42,22 @@ $color-aqua-darkest:         #046b99 !default;
 $color-aqua-light:           #9bdaf1 !default;
 $color-aqua-lightest:        #e1f3f8 !default;
 
+$color-red:            #e31c3d !default;
+$color-red-dark:       #cd2026 !default;
+$color-red-darkest:    #981b1e !default;
+$color-red-light:      #e59393 !default;
+$color-red-lightest:   #f9dede !default;
+
 $color-white:                #ffffff !default;
 $color-black:                #000000 !default;
 $color-black-light:          #212121 !default;
 
+$color-gold:                 #fdb81e !default;
+$color-gold-lightest:        #fff1d2 !default;
+
 $color-gray-dark:            #323a45 !default;
 $color-gray:                 #5b616b !default;
+$color-gray-medium:          #757575 !default;
 $color-gray-light:           #aeb0b5 !default;
 $color-gray-lighter:         #d6d7d9 !default;
 $color-gray-lightest:        #f1f1f1 !default;

--- a/public/css/core/_variables.scss
+++ b/public/css/core/_variables.scss
@@ -32,25 +32,25 @@ $font-normal:         400 !default;
 $font-bold:           700 !default;
 
 // Color
-$color-blue:                 #0071bc !default;
-$color-blue-darker:          #205493 !default;
-$color-blue-darkest:         #112e51 !default;
+$color-primary:              #0071bc !default;
+$color-primary-darker:       #205493 !default;
+$color-primary-darkest:      #112e51 !default;
 
-$color-aqua:                 #02c0e7 !default;
-$color-aqua-dark:            #00a6d2 !default;
-$color-aqua-darkest:         #046b99 !default;
-$color-aqua-light:           #9bdaf1 !default;
-$color-aqua-lightest:        #e1f3f8 !default;
+$color-primary-alt:          #02c0e7 !default;
+$color-primary-alt-dark:     #00a6d2 !default;
+$color-primary-alt-darkest:  #046b99 !default;
+$color-primary-alt-light:    #9bdaf1 !default;
+$color-primary-alt-lightest: #e1f3f8 !default;
 
-$color-red:            #e31c3d !default;
-$color-red-dark:       #cd2026 !default;
-$color-red-darkest:    #981b1e !default;
-$color-red-light:      #e59393 !default;
-$color-red-lightest:   #f9dede !default;
+$color-secondary:            #e31c3d !default;
+$color-secondary-dark:       #cd2026 !default;
+$color-secondary-darkest:    #981b1e !default;
+$color-secondary-light:      #e59393 !default;
+$color-secondary-lightest:   #f9dede !default;
 
 $color-white:                #ffffff !default;
 $color-black:                #000000 !default;
-$color-black-light:          #212121 !default;
+$color-black-light:           !default;
 
 $color-gold:                 #fdb81e !default;
 $color-gold-lightest:        #fff1d2 !default;
@@ -67,28 +67,9 @@ $color-green-light:          #4aa564 !default;
 $color-green-lighter:        #94bfa2 !default;
 $color-green-lightest:       #e7f4e4 !default;
 
-$color-purple:               #4c2c92 !default;
-
-// Functional colors
-$color-primary:              $color-blue !default;
-$color-primary-darker:       $color-blue-darker !default;
-$color-primary-darkest:      $color-blue-darkest !default;
-
-$color-primary-alt:          $color-aqua !default;
-$color-primary-alt-dark:     $color-aqua-dark !default;
-$color-primary-alt-darkest:  $color-aqua-darkest !default;
-$color-primary-alt-light:    $color-aqua-light !default;
-$color-primary-alt-lightest: $color-aqua-lightest !default;
-
-$color-secondary:            $color-red !default;
-$color-secondary-dark:       $color-red-dark !default;
-$color-secondary-darkest:    $color-red-darkest !default;
-$color-secondary-light:      $color-red-light !default;
-$color-secondary-lightest:   $color-red-lightest !default;
-
-$color-base:                 $color-black-light !default;
+$color-base:                 #212121 !default;
 $color-focus:                $color-gray-light !default;
-$color-visited:              $color-purple !default;
+$color-visited:              #4c2c92 !default;
 
 $color-shadow:               rgba(#000, 0.3) !default;
 $color-transparent:          rgba(#000, 0) !default;

--- a/public/css/core/_variables.scss
+++ b/public/css/core/_variables.scss
@@ -42,41 +42,20 @@ $color-aqua-darkest:         #046b99 !default;
 $color-aqua-light:           #9bdaf1 !default;
 $color-aqua-lightest:        #e1f3f8 !default;
 
-$color-red:                  #e31c3d !default;
-$color-red-dark:             #cd2026 !default;
-$color-red-darkest:          #981b1e !default;
-$color-red-light:            #e59393 !default;
-$color-red-lightest:         #f9dede !default;
-
 $color-white:                #ffffff !default;
 $color-black:                #000000 !default;
 $color-black-light:          #212121 !default;
 
 $color-gray-dark:            #323a45 !default;
 $color-gray:                 #5b616b !default;
-$color-gray-medium:          #757575 !default;
 $color-gray-light:           #aeb0b5 !default;
 $color-gray-lighter:         #d6d7d9 !default;
 $color-gray-lightest:        #f1f1f1 !default;
-
-$color-gray-warm-dark:       #494440 !default;
-$color-gray-warm-light:      #e4e2e0 !default;
-$color-gray-cool-light:      #dce4ef !default;
-
-$color-gold:                 #fdb81e !default;
-$color-gold-light:           #f9c642 !default;
-$color-gold-lighter:         #fad980 !default;
-$color-gold-lightest:        #fff1d2 !default;
 
 $color-green:                #2e8540 !default;
 $color-green-light:          #4aa564 !default;
 $color-green-lighter:        #94bfa2 !default;
 $color-green-lightest:       #e7f4e4 !default;
-
-$color-cool-blue:            #205493 !default;
-$color-cool-blue-light:      #4773aa !default;
-$color-cool-blue-lighter:    #8ba6ca !default;
-$color-cool-blue-lightest:   #dce4ef !default;
 
 $color-purple:               #4c2c92 !default;
 

--- a/public/css/elements/_table.scss
+++ b/public/css/elements/_table.scss
@@ -27,7 +27,7 @@ td {
 }
 
 caption {
-  @include h5;
+  @include h4;
   font-family: $font-serif;
   margin-bottom: 1.2rem;
   text-align: left;

--- a/public/css/elements/_typography.scss
+++ b/public/css/elements/_typography.scss
@@ -75,17 +75,8 @@ h3 {
   @include h3();
 }
 
-h4 {
+h4, h5, h6 {
   @include h4();
-}
-
-h5 {
-  @include h5();
-}
-
-h6 {
-  @include h6();
-  font-family: $font-sans;
 }
 
 // Remove user agent styles

--- a/public/css/overrides/01-atoms/01-fonts.scss
+++ b/public/css/overrides/01-atoms/01-fonts.scss
@@ -25,10 +25,10 @@
 }
 
 a:visited {
-  color: $color-blue;
+  color: $color-primary;
 }
 
 a:hover {
-  color: $color-blue-darker;
+  color: $color-primary-darker;
 }
 

--- a/public/css/overrides/01-atoms/01-fonts.scss
+++ b/public/css/overrides/01-atoms/01-fonts.scss
@@ -9,14 +9,6 @@
   @include merriweather;
 }
 
-.open-sans {
-  @include open-sans;
-}
-
-.montserrat {
-  @include montserrat;
-}
-
 .lead-paragraph {
   @include merriweather;
   font-size: 20px;

--- a/public/css/overrides/02-molecules/01-blocks/01-branding.scss
+++ b/public/css/overrides/02-molecules/01-blocks/01-branding.scss
@@ -3,7 +3,7 @@
 
 .branding-link {
   text-decoration: none;
-  color: $color-black-light;
+  color: $color-base;
 }
 
 .sfgov-logo__container {
@@ -47,7 +47,7 @@
         font-family: "Helvetica", sans-serif;
         font-size: 10px;
         line-height: 12px;
-        color: $color-black-light;
+        color: $color-base;
       }
       .sfgov-logo__text--title {
         @include merriweather;
@@ -55,7 +55,7 @@
         font-weight: bold;
         line-height: 26px;
         text-decoration: none;
-        color: $color-black-light;
+        color: $color-base;
       }
     }
   }

--- a/public/css/overrides/02-molecules/01-blocks/03-new-website.scss
+++ b/public/css/overrides/02-molecules/01-blocks/03-new-website.scss
@@ -8,7 +8,7 @@
     padding: 40px susy-span(1 wide of 12 wide) 40px;
   }
   h2 {
-    color: $color-blue-darkest;
+    color: $color-primary-darkest;
     padding: 0;
     margin: 0;
   }

--- a/public/css/overrides/02-molecules/02-navs/01-main-navigation.scss
+++ b/public/css/overrides/02-molecules/02-navs/01-main-navigation.scss
@@ -22,13 +22,13 @@ $hit-area: 4.4rem;
       a {
         @include source-sans-pro;
         font-size: 15px;
-        color: $color-blue-darkest;
+        color: $color-primary-darkest;
         line-height: 19px;
         font-weight: bold;
         text-decoration: none;
         &:hover, &.is-active {
           @include media($medium-screen + 1) {
-            border-bottom: 5px solid $color-blue-darker;
+            border-bottom: 5px solid $color-primary-darker;
             padding-bottom: 8px;
           }
         }
@@ -267,14 +267,14 @@ $hit-area: 4.4rem;
             &.is-active {
               font-weight: bold;
               border-bottom: 0;
-              border-left: 5px solid $color-blue-darker;
+              border-left: 5px solid $color-primary-darker;
               &:hover {
                 padding-left: 15px;
               }
             }
             &:hover {
               border-bottom: 0;
-              border-left: 5px solid $color-blue-darker;
+              border-left: 5px solid $color-primary-darker;
               padding-left: 10px;
             }
           }

--- a/public/css/overrides/02-molecules/02-navs/03-tabbed-navigation.scss
+++ b/public/css/overrides/02-molecules/02-navs/03-tabbed-navigation.scss
@@ -3,7 +3,7 @@
 
 .sfgov-tabbed-navigation {
   ul {
-    border-bottom: 1px solid $color-aqua-lightest;
+    border-bottom: 1px solid $color-primary-alt-lightest;
     margin: 10px 0 0 0;
     li {
       margin: 0;
@@ -13,7 +13,7 @@
         border: 1px solid $color-gray-lighter;
         text-decoration: none;
         &.is-active {
-          background: $color-aqua-lightest;
+          background: $color-primary-alt-lightest;
         }
       }
     }

--- a/public/css/overrides/02-molecules/03-heros/01-hero-banner.scss
+++ b/public/css/overrides/02-molecules/03-heros/01-hero-banner.scss
@@ -2,7 +2,7 @@
 @import './public/css/core/mixins';
 
 .sfgov-banner {
-  background: $color-aqua-lightest;
+  background: $color-primary-alt-lightest;
   .sfgov-banner__container {
     overflow: auto;
     padding: 42px 0 53px 0;
@@ -14,8 +14,7 @@
     }
   }
   h1 {
-    // todo: add this color to the styleguide.
-    color: $color-blue-darker;
+    color: $color-primary-darker;
     @include merriweather;
   }
   &.no-banner-text {

--- a/public/css/overrides/02-molecules/04-cards/01-transaction-card.scss
+++ b/public/css/overrides/02-molecules/04-cards/01-transaction-card.scss
@@ -5,7 +5,7 @@
   text-decoration: none;
   .transaction-card {
     &:hover {
-      background-color: $color-blue;
+      background-color: $color-primary;
       .transaction-card__title {
         color: $color-white;
       }

--- a/public/css/overrides/02-molecules/05-alerts/01-alert.scss
+++ b/public/css/overrides/02-molecules/05-alerts/01-alert.scss
@@ -60,7 +60,7 @@ $alerts-bar: map-merge($sfgov-alerts-bar, $sfgov-custom-alerts-bar);
 }
 
 .sfgov-alert-text {
-  @include open-sans;
+  @include source-sans-pro;
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/public/css/overrides/02-molecules/05-alerts/01-alert.scss
+++ b/public/css/overrides/02-molecules/05-alerts/01-alert.scss
@@ -59,8 +59,7 @@ $alerts-bar: map-merge($sfgov-alerts-bar, $sfgov-custom-alerts-bar);
   margin-bottom: 0;
 }
 
-.sfgov-alert-text {
-  @include source-sans-pro;
+.sfgov-alert-content {
   margin-bottom: 0;
   margin-top: 0;
 }

--- a/public/css/overrides/02-molecules/07-views/01-a-z-listing.scss
+++ b/public/css/overrides/02-molecules/07-views/01-a-z-listing.scss
@@ -16,7 +16,7 @@
     }
   }
   h3 {
-    background-color: $color-blue-darker;
+    background-color: $color-primary-darker;
     color: $color-white;
     font-size: 30px;
     line-height: 39px;
@@ -30,7 +30,7 @@
   .views-row {
     margin: 21px 0 14px 21px;
     a {
-      color: $color-blue-darker;
+      color: $color-primary-darker;
       font-size: 17px;
       line-height: 26px;
     }

--- a/public/css/overrides/02-molecules/10-person/10-person-section-display-hero.scss
+++ b/public/css/overrides/02-molecules/10-person/10-person-section-display-hero.scss
@@ -32,7 +32,7 @@
         font-weight: bold;
         a {
           text-decoration: none;
-          color: $color-blue;
+          color: $color-primary;
           > * {
             display: inline-block;
             text-decoration: none;

--- a/public/css/overrides/02-molecules/10-person/10-person-section-display.scss
+++ b/public/css/overrides/02-molecules/10-person/10-person-section-display.scss
@@ -28,7 +28,7 @@
     .person-name {
       a {
         text-decoration: underline;
-        color: $color-blue;
+        color: $color-primary;
         > * {
           display: inline-block;
           text-decoration: underline;

--- a/public/css/overrides/03-organisms/04-containers/01-sidebar.scss
+++ b/public/css/overrides/03-organisms/04-containers/01-sidebar.scss
@@ -34,7 +34,7 @@
   }
   h3 {
     margin-top: 0;
-    color: $color-blue-darker;
+    color: $color-primary-darker;
   }
   h4.field__label {
     @include source-sans-pro;

--- a/public/css/overrides/03-organisms/05-sections/01-section.scss
+++ b/public/css/overrides/03-organisms/05-sections/01-section.scss
@@ -6,7 +6,7 @@
 }
 
 .sfgov-section__title {
-  background: $color-blue-darker;
+  background: $color-primary-darker;
   color: #fff;
   padding: 16px 25px;
   margin-bottom: 20px;

--- a/public/css/overrides/03-organisms/05-sections/02-subsection-header.scss
+++ b/public/css/overrides/03-organisms/05-sections/02-subsection-header.scss
@@ -4,7 +4,7 @@
 .sfgov-subsection-header {
   margin-bottom: 40px;
   h3 {
-    color: $color-blue;
+    color: $color-primary;
     font-size: 2.4rem;
     font-family: "Merriweather","Georgia",sans-serif;
     font-weight: bold;


### PR DESCRIPTION
This PR brings our color and typography in line with the list in [Lauren's GDoc.]( I commented in the doc to note)

@josh-chou Feel free to reassign if you'd like... I'm just trying not to bombard Anthony!

### Changes

- Removed unused colors that Lauren also wants removed.

   There are a few instances where I haven't remove colors because they're being used by a component or two. I mentioned these in the GDoc.
- Renamed color variables to align with Lauren's docs (for example, `$color-blue` is now `$color-primary` everywhere)
- Removed Montserrat and Open Sans
- Applied `h4` styles to `h5` and `h6`, so that if someone inserts these elements accidentally, they'll just have `h4` styles
- [Unrelated] Fixed an incorrect class name for alerts

----

@laurenajong: While working on this, I found and fixed a styling bug with alerts!

Here's what they look like now, and what will change after this PR is merged.

![alert](https://user-images.githubusercontent.com/1328849/51716818-4401e680-1ff3-11e9-9e28-1a78331edbb6.png)
