### PR TITLE
Generate 2x maps on high-DPI / Retina screens

### DIFF
--- a/components/01-atoms/07-gmap/07-gmap.twig
+++ b/components/01-atoms/07-gmap/07-gmap.twig
@@ -3,7 +3,7 @@
 {% endif %}
 {% if include_static_map %}
     <div class="simple-gmap-static-map">
-        <a href="https://maps.google.com/maps?q={{ url_suffix }}&amp;hl={{ langcode }}&amp;t={{ map_type }}&amp;z={{ zoom }}" target="_blank"><img src="https://maps.googleapis.com/maps/api/staticmap?size={{ width }}x{{ height }}&amp;scale={{ static_scale }}&amp;zoom={{ zoom }}&amp;language={{ langcode }}&amp;maptype={{ static_map_type }}&amp;markers=color:red|{{ url_suffix }}&amp;sensor=false&amp;key={{ apikey }} " style="border:1px solid #D5D5D5;" /> </a>
+        <a href="https://maps.google.com/maps?q={{ url_suffix }}&amp;hl={{ langcode }}&amp;t={{ map_type }}&amp;z={{ zoom }}" target="_blank"><img src="https://maps.googleapis.com/maps/api/staticmap?size={{ width }}x{{ height }}&amp;scale=1&amp;zoom={{ zoom }}&amp;language={{ langcode }}&amp;maptype={{ static_map_type }}&amp;markers=color:red|{{ url_suffix }}&amp;sensor=false&amp;key={{ apikey }}" srcset="https://maps.googleapis.com/maps/api/staticmap?size={{ width }}x{{ height }}&amp;scale=2&amp;zoom={{ zoom }}&amp;language={{ langcode }}&amp;maptype={{ static_map_type }}&amp;markers=color:red|{{ url_suffix }}&amp;sensor=false&amp;key={{ apikey }} 2x" style="border:1px solid #D5D5D5;" /> </a>
     </div>
 {% endif %}
 {% if include_link %}


### PR DESCRIPTION
cc: @josh-chou... This removes the need for the `static_scale` attribute in SFGov (like [here](https://github.com/SFDigitalServices/sfgov/blob/3d41d9358c1a6581115e1a17119b046f3bdefb41/config/core.entity_view_display.location.physical.default.yml#L38)), since the static_scale will depend on the device's pixel density.

Based on the [GMaps API docs](https://developers.google.com/maps/documentation/maps-static/dev-guide#scale_values), we can ask for `scale=2` images for free. We'd need a premium plan if we wanted to optimize for even higher-resolution screens (like the iPhone XS.)