### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = spaces
+indent_size = 2


### PR DESCRIPTION
In keeping with [the formbuilder](https://sfgovdt.jira.com/browse/DFB-373), this file helps ensure our commits [maintain a consistent coding style.](https://editorconfig.org/#overview)

They should work automatically with most editors, but some (like Emacs, Notepad++ and Atom) require you to [download a plugin.](https://editorconfig.org/#download)

@aekong and @hshaosf, these settings are just what I'm used to, but I don't care too much about any of them. Happy to change any of them if you have strong opinions.