### PR TITLE
update image paths in dist css to relative

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -16,6 +16,7 @@ import shell from 'gulp-shell';
 import concat from 'gulp-concat';
 import babel from 'gulp-babel';
 import imagemin from 'gulp-imagemin';
+import replace from 'gulp-replace';
 
 let importOnce = require('node-sass-import-once');
 
@@ -66,6 +67,7 @@ gulp.task('pl:css', () => {
             importer: importOnce
         }))
         .pipe(autoprefix('last 2 versions', '> 1%', 'ie 9', 'ie 10'))
+        .pipe(replace('url("/images/', 'url("../images/'))
         .pipe(sourcemaps.write('./'))
         .pipe(gulp.dest(config.css.dist_folder))
         .pipe(browserSync.reload({stream: true, match: '**/*.css'}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -6977,6 +6977,33 @@
       "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.3.tgz",
       "integrity": "sha512-CmdPM0BjJ105QCX1fk+j7NGhiN/1rCl9HLGss+KllBS/tdYadpjTxqdKyh/5fNV+M3yjT1MFz5z93bXdrTyzAw=="
     },
+    "gulp-replace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-1.0.0.tgz",
+      "integrity": "sha512-lgdmrFSI1SdhNMXZQbrC75MOl1UjYWlOWNbNRnz+F/KHmgxt3l6XstBoAYIdadwETFyG/6i+vWUSCawdC3pqOw==",
+      "requires": {
+        "istextorbinary": "2.2.1",
+        "readable-stream": "^2.0.1",
+        "replacestream": "^4.0.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+          "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg=="
+        },
+        "istextorbinary": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.2.1.tgz",
+          "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
+          "requires": {
+            "binaryextensions": "2",
+            "editions": "^1.3.3",
+            "textextensions": "2"
+          }
+        }
+      }
+    },
     "gulp-sass": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-4.0.2.tgz",
@@ -10899,6 +10926,16 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
       "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
+    },
+    "replacestream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-4.0.3.tgz",
+      "integrity": "sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==",
+      "requires": {
+        "escape-string-regexp": "^1.0.3",
+        "object-assign": "^4.0.1",
+        "readable-stream": "^2.0.2"
+      }
     },
     "request": {
       "version": "2.88.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bourbon-neat": "^1.9.0",
     "browser-sync": "^2.26.7",
     "gulp-imagemin": "^4.1.0",
+    "gulp-replace": "^1.0.0",
     "gutter-grid": "^7.0.0",
     "normalize.scss": "^0.1.0",
     "susy": "^3.0.5",


### PR DESCRIPTION
Currently, some image paths in CSS are absolute linked, which could cause issues if the project using the sf-design-system did not or cannot place the distribution folder in the root web directory when referenced. 