### PR TITLE
Separate typography mixins from style rules

### DIFF
--- a/src/components/00-design-tokens/_typography-mixins.scss
+++ b/src/components/00-design-tokens/_typography-mixins.scss
@@ -5,6 +5,8 @@ $fw-regular: 400;
 $fw-medium: 500;
 $fw-bold: 700;
 $fw-black: 900;
+$fw-black: 900;
+
 
 @mixin antialiasing($type:antialiased) {
   /* antialiased, none, subpixel-antialiased*/
@@ -84,26 +86,6 @@ $fw-black: 900;
   font-weight: $fw-medium;
   @include font-size-to-rem(20);
   @include line-height-to-rem(27);
-}
-
-h1, .h1 {
-  @include h1;
-}
-
-h2, .h2 {
-  @include h2;
-}
-
-h3, .h3 {
-  @include h3;
-}
-
-h4, .h4 {
-  @include h4;
-}
-
-h5, .h5 {
-  @include h5;
 }
 
 @mixin display-1 {

--- a/src/components/00-design-tokens/_typography-mixins.scss
+++ b/src/components/00-design-tokens/_typography-mixins.scss
@@ -5,8 +5,6 @@ $fw-regular: 400;
 $fw-medium: 500;
 $fw-bold: 700;
 $fw-black: 900;
-$fw-black: 900;
-
 
 @mixin antialiasing($type:antialiased) {
   /* antialiased, none, subpixel-antialiased*/

--- a/src/components/00-design-tokens/_typography.scss
+++ b/src/components/00-design-tokens/_typography.scss
@@ -1,7 +1,19 @@
-$base-font-size: 1.0625rem;
+h1, .h1 {
+  @include h1;
+}
 
-$fw-light: 300;
-$fw-regular: 400;
-$fw-medium: 500;
-$fw-bold: 700;
-$fw-black: 900;
+h2, .h2 {
+  @include h2;
+}
+
+h3, .h3 {
+  @include h3;
+}
+
+h4, .h4 {
+  @include h4;
+}
+
+h5, .h5 {
+  @include h5;
+}


### PR DESCRIPTION
While integrating the PL into the formbuilder, I realized I introduced two issues in #22:

- The variables in `typography-mixins` were overriding those in `typography`, making the latter stylesheet irrelevant
- You can't `@import 'typography-mixins'` without adding unnecessary styles (for h1s, h2s, etc.) to your stylesheet

This PR fixes both of these problems. 