### PR TITLE
Fix styling bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-design-system",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "[![CircleCI](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master.svg?style=shield)](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master) [![Site sf-design-system](https://img.shields.io/badge/site-sf--design--system-blue.svg)](https://sfdigitalservices.github.io/sf-design-system/)",
   "main": "fractal.js",
   "directories": {

--- a/src/components/00-design-tokens/_typography-mixins.scss
+++ b/src/components/00-design-tokens/_typography-mixins.scss
@@ -95,7 +95,7 @@ $fw-black: 900;
   @media screen and (min-width: $mq-medium) {
     @include font-size-to-rem(72);
     @include line-height-to-rem(80.2);
-    letter-spacing: 0.12rem;
+    letter-spacing: -0.12rem;
   }
 }
 

--- a/src/components/00-design-tokens/_typography.scss
+++ b/src/components/00-design-tokens/_typography.scss
@@ -1,3 +1,11 @@
+html {
+	font-size: 1.0625rem;
+}
+
+body {
+	@include line-height-to-rem(28);
+}
+
 h1, .h1 {
   @include h1;
 }

--- a/src/components/03-layout/headers/_hero-banner.scss
+++ b/src/components/03-layout/headers/_hero-banner.scss
@@ -67,10 +67,13 @@
 
 .form-progress {
   position: relative;
+  height: 1.5rem;
+  margin: 0.25rem 0;
   @media screen and (min-width: $mq-medium) {
     position: absolute;
     top: 0;
     right: 0;
+    margin: 0;
   }
 }
 
@@ -79,13 +82,16 @@
   padding: 0.25rem 1rem;
   border-radius: 1.5rem;
   display: inline-block;
-  margin: 0.5rem 0;
+  position: absolute;
+  top: 0;
+  white-space: nowrap;
+  font-size: 1rem;
+  line-height: 1;
   @media screen and (min-width: $mq-medium) {
-    position: relative;
     top: -0.25rem;
+    right: 0;
     margin: 0;
   }
-  font-size: 1rem;
 }
 
 .form-progress-bar {
@@ -94,9 +100,9 @@
   background: $purple-1;
   height: 0.75rem;
   display: inline-block;
-  width: 10rem;
-  position: relative;
-  top: -0.125rem;
+  width: 100%;
+  position: absolute;
+  top: 0.25rem;
   border-radius: 0.375rem;
   &::before {
     content: '';
@@ -106,6 +112,15 @@
     position: absolute;
     top: 0;
     left: 0;
+  }
+  @media screen and (min-width: $mq-medium) {
+    top: 0;
+    right: 0;
+    height: 0.75rem;
+    width: 10rem;
+    &::before {
+      height: 0.75rem;
+    }
   }
 }
 


### PR DESCRIPTION
Noticed these while working on the ADU prototype...

### The biggest change

Our global `font-size` and `line-height` is now set to "Body Long", so that we don't need to add classes to every paragraph tag.

This will affect every pattern, so it's worth taking a quick look at them all.

### Other changes

- Fixed a typo in the `display-1` mixin
- Improved the spacing in the "Hero Banner - Form" mobile styles