### PR TITLE
Spacing / layout improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-design-system",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "[![CircleCI](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master.svg?style=shield)](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master) [![Site sf-design-system](https://img.shields.io/badge/site-sf--design--system-blue.svg)](https://sfdigitalservices.github.io/sf-design-system/)",
   "main": "fractal.js",
   "directories": {

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -14,6 +14,12 @@
   outline: none;
 }
 
+// Layout
+
+.form-content {
+  @include contain-1090;
+}
+
 // Cross-browser consistency / bug fixes
 
 input::-webkit-outer-spin-button,
@@ -315,6 +321,10 @@ $rc-size: 3rem;
     padding-left: $rc-size + 0.75rem;
     margin-bottom: 1rem;
     min-height: $rc-size;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   input,

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -18,6 +18,7 @@
 
 .form-content {
   @include contain-1090;
+  margin-top: 2rem;
 }
 
 // Cross-browser consistency / bug fixes

--- a/src/components/04-forms/layout/_pagination.scss
+++ b/src/components/04-forms/layout/_pagination.scss
@@ -29,7 +29,7 @@
 .form-section-prev,
 .form-section-next,
 .form-section-submit {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   cursor: pointer;
 }
 


### PR DESCRIPTION
### List of changes

- Remove the margin for the last option in a radio button or checkbox field, to ensure consistent spacing between all field types 
- Add spacing between header and form 
- Reduce spacing between pagination buttons and the last form field on a page
- Add `contain-1090` to the form's container `div`
- Bump package version