### PR TITLE
DFB-700: Fix gratuitous margins for static content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-design-system",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "[![CircleCI](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master.svg?style=shield)](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master) [![Site sf-design-system](https://img.shields.io/badge/site-sf--design--system-blue.svg)](https://sfdigitalservices.github.io/sf-design-system/)",
   "main": "fractal.js",
   "directories": {

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -103,6 +103,9 @@ legend {
 
 .form-group {
   position: relative;
+}
+
+.form-group-field {
   margin-bottom: 2.5rem;
 
   p + &,


### PR DESCRIPTION
We're already applying margins to header and text elements within a `.form-group`, so spacing between form fields should only apply to actual inputs.