### PR TITLE
Optically adjust progress bar

### DIFF
--- a/src/components/03-layout/headers/_hero-banner.scss
+++ b/src/components/03-layout/headers/_hero-banner.scss
@@ -124,7 +124,12 @@
   }
 }
 
-@for $i from 1 to 90 {
+.form-progress-bar-1,
+.form-progress-bar-2 {
+  width: 3%;
+}
+
+@for $i from 3 to 90 {
   .form-progress-bar-#{$i}::before {
     width: $i * 1%;
   }


### PR DESCRIPTION
When a form is less than 3% complete, the progress bar is so small it looks broken:

<img width="193" alt="Screen Shot 2020-01-30 at 3 01 39 PM" src="https://user-images.githubusercontent.com/1328849/73498211-7e723200-4371-11ea-9698-3f8f3115b590.png">

This PR fixes the problem by forcing a minimum width of 3% for the progress bar:

<img width="202" alt="Screen Shot 2020-01-30 at 3 01 21 PM" src="https://user-images.githubusercontent.com/1328849/73498254-9cd82d80-4371-11ea-8f84-ffab84d14ad4.png">

 On a 100-page form, this means the progress bar might not move for the first few pages, but I think that's OK.