### PR TITLE
Automate npm publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           name: Install dependencies
           command: |
             npm install
-            npm install -g fx
+            npm install --no-save fx
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
+version: 2.1
+
+orbs:
+  jq: circleci/jq@1.9.1
+
 jobs:
   build:
     branches:
@@ -39,17 +43,17 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package-lock.json" }}
-      
+
       - run:
           name: Install composer
           command: ./.circleci/scripts/install-composer.sh
-      
+
       - run:
           name: Install terminus
           command: |
             cd ..
             curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
 
-      - deploy: 
+      - deploy:
           name: Deploy
           command: ./.circleci/scripts/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,7 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2.1
-
-orbs:
-  jq: circleci/jq@1.9.1
+version: 2
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Install terminus
           command: |
             cd ..
-            curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
+            composer require pantheon-systems/terminus
 
       - deploy:
           name: Deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: npm install
+          command: |
+            npm install
+            npm install -g fx
 
       - save_cache:
           paths:

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -15,7 +15,7 @@ git checkout $CIRCLE_BRANCH || git checkout --orphan $CIRCLE_BRANCH
 
 GITHUB_REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 GIT_COMMIT_MSG=$(git log --pretty=format:"%h: %s" -n 1)
-NPM_PACKAGE_VERSION=$(jq -r .version package.json)
+NPM_PACKAGE_VERSION=$(fx package.json .version)
 GIT_TAG="v$NPM_PACKAGE_VERSION"
 SHORT_SHA="${CIRCLE_SHA1:1:7}"
 
@@ -31,9 +31,8 @@ ssh-add ~/.ssh/id_rsa_$PANTHEON_SSH_FINGERPRINT
 ssh-keyscan -H -p $PANTHEON_CODESERVER_PORT $PANTHEON_CODESERVER >> ~/.ssh/known_hosts
 
 # static site build and deploy
-npm install
 export NODE_ENV=production # exit properly on gulp errors
-./node_modules/gulp/bin/gulp.js export # gulp task defined in gulpfile.babel.js to export static reference site
+npm run export
 cp -r src .. # copy out src to bring back in later for distribution branch
 cp -r .circleci ..
 git rm -rf .

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -15,7 +15,7 @@ git checkout $CIRCLE_BRANCH || git checkout --orphan $CIRCLE_BRANCH
 
 GITHUB_REPO="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
 GIT_COMMIT_MSG=$(git log --pretty=format:"%h: %s" -n 1)
-NPM_PACKAGE_VERSION=$(fx package.json .version)
+NPM_PACKAGE_VERSION=$(npx fx package.json .version)
 GIT_TAG="v$NPM_PACKAGE_VERSION"
 SHORT_SHA="${CIRCLE_SHA1:1:7}"
 

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -32,6 +32,7 @@ ssh-keyscan -H -p $PANTHEON_CODESERVER_PORT $PANTHEON_CODESERVER >> ~/.ssh/known
 
 # static site build and deploy
 export NODE_ENV=production # exit properly on gulp errors
+npm install
 npm run export
 cp -r src .. # copy out src to bring back in later for distribution branch
 cp -r .circleci ..

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -63,7 +63,7 @@ if [ $CIRCLE_BRANCH == $SOURCE_BRANCH ]; then
   git tag -a $GIT_DIST_TAG -m "$GIT_DIST_MSG"
   git push origin $GIT_DIST_TAG
 else
-  site_id="preview-$CIRCLE_BRANCH"
+  site_id="preview-$CIRCLE_BUILD_NUM"
   git commit -m "build branch '$CIRCLE_BRANCH' to pantheon remote $site_id: $GIT_COMMIT_MSG" --allow-empty
 
   # terminus commands
@@ -82,7 +82,7 @@ else
   fi
 
   terminus multidev:create $PANTHEON_SITENAME.dev $site_id
-  git push -f pantheon $CIRCLE_BRANCH:ci-$CIRCLE_BUILD_NUM
+  git push -f pantheon "$CIRCLE_BRANCH:$site_id"
   terminus auth:logout
 
   # usage: hub METHOD url "{data}"

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -87,13 +87,16 @@ else
 
   site_url="https://$site_id-sfdesignsystem.pantheonsite.io"
 
-  curl -u "aekong:$GH_ACCESS_TOKEN" -X POST -H "Content-Type: application/json" \
-    -d '{"context":"preview site","state":"success","target_url":"'"$site_url"'","description":"preview deployed"}' \
-    "https://api.github.com/repos/$GITHUB_REPO/statuses/$CIRCLE_SHA1"
+  # usage: hub METHOD url "{data}"
+  function github {
+    curl -u "${GH_ACCESS_USER-aekong}:$GH_ACCESS_TOKEN" \
+      -X "${1-POST}" -H "Content-Type: application/json" \
+      -d "$3" \
+      "https://api.github.com/repos/${GITHUB_REPO}${2}"
+  }
+
+  github POST "/statuses/$CIRCLE_SHA1" '{"context":"preview site","state":"success","target_url":"'"$site_url"'","description":"preview deployed"}'
 
   # comment on commit with review site
-  COMMENT="review site: https://ci-${CIRCLE_BUILD_NUM}-sfdesignsystem.pantheonsite.io"
-  OWNER="SFDigitalServices"
-  REPO="sf-design-system"
-  # curl -u aekong:$GH_ACCESS_TOKEN -H "Content-Type: application/json" -d '{"body":"'"$COMMENT"'"}' -X POST https://api.github.com/repos/$OWNER/$REPO/commits/$CIRCLE_SHA1/comments
+  # github POST "/commits/$CIRCLE_SHA1/comments" '{"body":"'"review site: $site_url"'"}'
 fi

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -31,9 +31,8 @@ ssh-add ~/.ssh/id_rsa_$PANTHEON_SSH_FINGERPRINT
 ssh-keyscan -H -p $PANTHEON_CODESERVER_PORT $PANTHEON_CODESERVER >> ~/.ssh/known_hosts
 
 # static site build and deploy
-export NODE_ENV=production # exit properly on gulp errors
 npm install
-npm run export
+NODE_ENV=production npm run export
 cp -r src .. # copy out src to bring back in later for distribution branch
 cp -r .circleci ..
 git rm -rf .

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -93,9 +93,10 @@ else
       "https://api.github.com/repos/${GITHUB_REPO}${2}"
   }
 
-  site_url="https://$site_id-sfdesignsystem.pantheonsite.io"
+  site_domain="$site_id-sfdesignsystem.pantheonsite.io"
+  site_url="https://$site_domain"
 
-  github POST "/statuses/$CIRCLE_SHA1" '{"context":"preview site","state":"success","target_url":"'"$site_url"'","description":"preview deployed"}'
+  github POST "/statuses/$CIRCLE_SHA1" '{"context":"preview site","state":"success","target_url":"'"$site_url"'","description":"'"$site_domain"'"}'
 
   # comment on commit with review site
   # github POST "/commits/$CIRCLE_SHA1/comments" '{"body":"'"review site: $site_url"'"}'

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -86,5 +86,5 @@ else
   COMMENT="review site: https://ci-${CIRCLE_BUILD_NUM}-sfdesignsystem.pantheonsite.io"
   OWNER="SFDigitalServices"
   REPO="sf-design-system"
-  curl -u aekong:$GH_ACCESS_TOKEN -H "Content-Type: application/json" -d '{"body":"'"$COMMENT"'"}' -X POST https://api.github.com/repos/$OWNER/$REPO/commits/$CIRCLE_SHA1/comments
+  # curl -u aekong:$GH_ACCESS_TOKEN -H "Content-Type: application/json" -d '{"body":"'"$COMMENT"'"}' -X POST https://api.github.com/repos/$OWNER/$REPO/commits/$CIRCLE_SHA1/comments
 fi

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -63,7 +63,7 @@ if [ $CIRCLE_BRANCH == $SOURCE_BRANCH ]; then
   git tag -a $GIT_DIST_TAG -m "$GIT_DIST_MSG"
   git push origin $GIT_DIST_TAG
 else
-  site_id="ci-$CIRCLE_BUILD_NUM"
+  site_id="preview-$CIRCLE_BRANCH"
   git commit -m "build branch '$CIRCLE_BRANCH' to pantheon remote $site_id: $GIT_COMMIT_MSG" --allow-empty
 
   # terminus commands
@@ -85,8 +85,6 @@ else
   git push -f pantheon $CIRCLE_BRANCH:ci-$CIRCLE_BUILD_NUM
   terminus auth:logout
 
-  site_url="https://$site_id-sfdesignsystem.pantheonsite.io"
-
   # usage: hub METHOD url "{data}"
   function github {
     curl -u "${GH_ACCESS_USER-aekong}:$GH_ACCESS_TOKEN" \
@@ -94,6 +92,8 @@ else
       -d "$3" \
       "https://api.github.com/repos/${GITHUB_REPO}${2}"
   }
+
+  site_url="https://$site_id-sfdesignsystem.pantheonsite.io"
 
   github POST "/statuses/$CIRCLE_SHA1" '{"context":"preview site","state":"success","target_url":"'"$site_url"'","description":"preview deployed"}'
 

--- a/.circleci/scripts/deploy.sh
+++ b/.circleci/scripts/deploy.sh
@@ -3,10 +3,10 @@
 set -eo pipefail
 
 # add terminus to path
-export PATH=$PATH:/home/circleci/vendor/bin
+export PATH="$PATH:/home/circleci/vendor/bin"
 
-git config --global user.email $GH_EMAIL
-git config --global user.name $GH_NAME
+git config --global user.email "$GH_EMAIL"
+git config --global user.name "$GH_NAME"
 
 git clone $CIRCLE_REPOSITORY_URL $CIRCLE_BRANCH
 cd $CIRCLE_BRANCH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
           npm run before-publish
 
       - name: publish
-        run: 'npm publish --tag="$(cat DIST_TAG)" --dry-run'
+        run: 'npm publish --tag="$(cat DIST_TAG)"'
 
       - name: postpublish
         run: npm run after-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: CI
 on: [push]
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,38 +16,29 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      DIST_TAG: canary
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
           node-version: 12
 
-      - env:
-          GIT_SHA: "$(git rev-parse --short HEAD)"
-          GIT_BRANCH: "$(git symbolic-ref --short HEAD)"
-          PACKAGE_VERSION: "$(npx fx package.json .version)"
-          DIST_TAG: canary
-        run: |
-          echo "GIT_SHA: '$GIT_SHA'"
-          echo "GIT_BRANCH: '$GIT_BRANCH'"
-          echo "PACKAGE_VERSION: '$PACKAGE_VERSION'"
-          echo "DIST_TAG: '$DIST_TAG'"
-
       - name: tag latest
-        if: env.GIT_BRANCH == 'master'
+        if: github.ref == 'refs/heads/master'
         env:
           DIST_TAG: latest
         run: echo '*** this will publish to the latest dist-tag! ***'
 
       - name: tag release candidate
-        if: "startsWith(env.GIT_BRANCH, 'release-')"
+        if: startsWith(github.ref, 'refs/heads/release-')
         env:
           DIST_TAG: rc
-        run: npm version "${PACKAGE_VERSION}-rc.${GIT_SHA}"
+        run: npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"
 
       - name: tag canary
         if: env.DIST_TAG == 'canary'
-        run: npm version "0.0.0-${GIT_SHA}"
+        run: npm version "0.0.0-$(git rev-parse --short HEAD)"
 
       - name: publish
-        run: npm publish --tag="$DIST_TAG" --dry-run
+        run: npm publish --tag="${{ env.DIST_TAG }}" --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,10 @@ jobs:
           PACKAGE_VERSION: "$(npx fx package.json .version)"
           DIST_TAG: canary
         run:
-          - echo "GIT_SHA: '$GIT_SHA'"
-          - echo "GIT_BRANCH: '$GIT_BRANCH'"
-          - echo "PACKAGE_VERSION: '$PACKAGE_VERSION'"
-          - echo "DIST_TAG: '$DIST_TAG'"
+          - "echo \"GIT_SHA: '$GIT_SHA'\""
+          - "echo \"GIT_BRANCH: '$GIT_BRANCH'\""
+          - "echo \"PACKAGE_VERSION: '$PACKAGE_VERSION'\""
+          - "echo \"DIST_TAG: '$DIST_TAG'\""
 
       - name: tag latest
         if: env.GIT_BRANCH == 'master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://registry.npmjs.org
+          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,12 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
       - run: npm test
       - run: gulp build
 
-      - uses: shawnbot/npm-publish-action@master
+      - uses: primer/publish@v2.0.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,13 @@ jobs:
         if: env.GIT_BRANCH == 'master'
         env:
           DIST_TAG: latest
+        run: echo '*** this will publish to the latest dist-tag! ***'
 
       - name: tag release candidate
         if: "startsWith(env.GIT_BRANCH, 'release-')"
-        run: npm version "${PACKAGE_VERSION}-rc.${GIT_SHA}"
         env:
           DIST_TAG: rc
+        run: npm version "${PACKAGE_VERSION}-rc.${GIT_SHA}"
 
       - name: tag canary
         if: env.DIST_TAG == 'canary'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,13 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 12
+          registry-url: https://registry.npmjs.org
 
       - run: npm ci
       - run: npm test
       - run: gulp build
 
-      - uses: primer/publish@v1.1.0
+      - uses: shawnbot/npm-publish-action@master
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,33 +26,6 @@ jobs:
         with:
           node-version: 12
 
-      - name: publish setup
-        run: |
-          echo "$NPM_REGISTRY_URL:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc
-          # this prevents `npm version` from committing to git
-          npm config set git-tag-version false
-
-      - name: tag latest
-        if: github.ref == 'refs/heads/master'
-        run: npm config set tag latest
-
-      - name: tag release candidate
-        if: startsWith(github.ref, 'refs/heads/release-')
-        run: |
-          npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"
-          npm config set tag next
-
-      - name: tag canary
-        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release-')
-        run: |
-          npm version "0.0.0-$(git rev-parse --short HEAD)"
-          npm config set tag canary
-
-      - name: prepublish
-        run: npm run before-publish
-
-      - name: publish
-        run: npm publish
-
-      - name: postpublish
-        run: npm run after-publish
+      - uses: primer/publish@master
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           node-version: 12
       - run: npm ci
-      - run: npm test
+      # - run: npm test
       - run: gulp build
 
   publish:
@@ -23,6 +23,9 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 12
+
+      # this prevents `npm version` from committing to git
+      - run: npm config set git-tag-version false
 
       - name: tag latest
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      DIST_TAG: canary
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
@@ -25,23 +27,31 @@ jobs:
           node-version: 12
 
       # this prevents `npm version` from committing to git
-      - run: npm config set git-tag-version false
+      - run: 'npm config set git-tag-version false'
 
       - name: tag latest
         if: github.ref == 'refs/heads/master'
         env:
           DIST_TAG: latest
-        run: echo '*** this will publish to the latest dist-tag! ***'
+        run: 'echo "*** this will publish to the latest dist-tag! ***"'
 
       - name: tag release candidate
         if: startsWith(github.ref, 'refs/heads/release-')
         env:
           DIST_TAG: rc
-        run: npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"
+        run: 'npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"'
 
       - name: tag canary
-        if: env.DIST_TAG == 'canary'
-        run: npm version "0.0.0-$(git rev-parse --short HEAD)"
+        if: '!env.DIST_TAG'
+        env:
+          DIST_TAG: canary
+        run: 'npm version "0.0.0-$(git rev-parse --short HEAD)"'
+
+      - name: prepublish
+        run: npm run prepublish
 
       - name: publish
-        run: npm publish --tag="${{ env.DIST_TAG }}" --dry-run
+        run: 'npm publish --tag="${{ env.DIST_TAG }}" --dry-run'
+
+      - name: postpublish
+        run: npm run postpublish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: Publish to npm
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+      - run: gulp build
+
+  publish:
+    needs: build
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@master
+        with:
+          node-version: 12
+
+      - env:
+          GIT_SHA: "$(git rev-parse --short HEAD)"
+          GIT_BRANCH: "$(git symbolic-ref --short HEAD)"
+          PACKAGE_VERSION: "$(npx fx package.json .version)"
+          DIST_TAG: canary
+        run:
+          - echo "GIT_SHA: '$GIT_SHA'"
+          - echo "GIT_BRANCH: '$GIT_BRANCH'"
+          - echo "PACKAGE_VERSION: '$PACKAGE_VERSION'"
+          - echo "DIST_TAG: '$DIST_TAG'"
+
+      - name: tag latest
+        if: env.GIT_BRANCH == 'master'
+        env:
+          DIST_TAG: latest
+
+      - name: tag release candidate
+        if: "startsWith(env.GIT_BRANCH, 'release-')"
+        run: npm version "${PACKAGE_VERSION}-rc.${GIT_SHA}"
+        env:
+          DIST_TAG: rc
+
+      - name: tag canary
+        if: env.DIST_TAG == 'canary'
+        run: npm version "0.0.0-${GIT_SHA}"
+
+      - name: publish
+        run: npm publish --tag="$DIST_TAG" --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,23 +9,12 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 12
+
       - run: npm ci
       # - run: npm test
       - run: gulp build
 
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
-      NPM_REGISTRY_URL: //registry.npmjs.org/
-
-    steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-node@master
-        with:
-          node-version: 12
-
       - uses: primer/publish@master
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
         with:
           node-version: 12
 
-      # this prevents `npm version` from committing to git
-      - run: 'npm config set git-tag-version false'
-      - run: 'echo canary > DIST_TAG'
+      - name: publish setup
+        run: |
+          # this prevents `npm version` from committing to git
+          npm config set git-tag-version false
+          echo canary > DIST_TAG
 
       - name: tag latest
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
           GIT_BRANCH: "$(git symbolic-ref --short HEAD)"
           PACKAGE_VERSION: "$(npx fx package.json .version)"
           DIST_TAG: canary
-        run:
-          - "echo \"GIT_SHA: '$GIT_SHA'\""
-          - "echo \"GIT_BRANCH: '$GIT_BRANCH'\""
-          - "echo \"PACKAGE_VERSION: '$PACKAGE_VERSION'\""
-          - "echo \"DIST_TAG: '$DIST_TAG'\""
+        run: |
+          echo "GIT_SHA: '$GIT_SHA'"
+          echo "GIT_BRANCH: '$GIT_BRANCH'"
+          echo "PACKAGE_VERSION: '$PACKAGE_VERSION'"
+          echo "DIST_TAG: '$DIST_TAG'"
 
       - name: tag latest
         if: env.GIT_BRANCH == 'master'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ github.token }}
-      NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+      NPM_REGISTRY_URL: //registry.npmjs.org/
 
     steps:
       - uses: actions/checkout@master
@@ -28,31 +28,31 @@ jobs:
 
       - name: publish setup
         run: |
+          echo "$NPM_REGISTRY_URL:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc
           # this prevents `npm version` from committing to git
           npm config set git-tag-version false
-          echo canary > DIST_TAG
 
       - name: tag latest
         if: github.ref == 'refs/heads/master'
-        run: 'echo latest > DIST_TAG'
+        run: npm config set tag latest
 
       - name: tag release candidate
         if: startsWith(github.ref, 'refs/heads/release-')
         run: |
           npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"
-          echo next > DIST_TAG
+          npm config set tag next
 
       - name: tag canary
-        if: '!env.DIST_TAG'
-        run: 'npm version "0.0.0-$(git rev-parse --short HEAD)"'
+        if: github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/heads/release-')
+        run: |
+          npm version "0.0.0-$(git rev-parse --short HEAD)"
+          npm config set tag canary
 
       - name: prepublish
-        run: |
-          echo "Publishing to dist-tag: '$(cat DIST_TAG)'..."
-          npm run before-publish
+        run: npm run before-publish
 
       - name: publish
-        run: 'npm publish --tag="$(cat DIST_TAG)"'
+        run: npm publish
 
       - name: postpublish
         run: npm run after-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
     steps:
@@ -49,10 +49,10 @@ jobs:
       - name: prepublish
         run: |
           echo "Publishing to dist-tag: '$(cat DIST_TAG)'..."
-          npm run prepublish
+          npm run before-publish
 
       - name: publish
         run: 'npm publish --tag="$(cat DIST_TAG)" --dry-run'
 
       - name: postpublish
-        run: npm run postpublish
+        run: npm run after-publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
 
   publish:
     needs: build
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
           node-version: 12
 
       - run: npm ci
-      # - run: npm test
+      - run: npm test
       - run: gulp build
 
-      - uses: primer/publish@master
+      - uses: primer/publish@v1.1.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,30 +28,29 @@ jobs:
 
       # this prevents `npm version` from committing to git
       - run: 'npm config set git-tag-version false'
+      - run: 'echo canary > DIST_TAG'
 
       - name: tag latest
         if: github.ref == 'refs/heads/master'
-        env:
-          DIST_TAG: latest
-        run: 'echo "*** this will publish to the latest dist-tag! ***"'
+        run: 'echo latest > DIST_TAG'
 
       - name: tag release candidate
         if: startsWith(github.ref, 'refs/heads/release-')
-        env:
-          DIST_TAG: rc
-        run: 'npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"'
+        run: |
+          npm version "$(npx fx package.json .version)-rc.$(git rev-parse --short HEAD)"
+          echo next > DIST_TAG
 
       - name: tag canary
         if: '!env.DIST_TAG'
-        env:
-          DIST_TAG: canary
         run: 'npm version "0.0.0-$(git rev-parse --short HEAD)"'
 
       - name: prepublish
-        run: npm run prepublish
+        run: |
+          echo "Publishing to dist-tag: '$(cat DIST_TAG)'..."
+          npm run prepublish
 
       - name: publish
-        run: 'npm publish --tag="${{ env.DIST_TAG }}" --dry-run'
+        run: 'npm publish --tag="$(cat DIST_TAG)" --dry-run'
 
       - name: postpublish
         run: npm run postpublish

--- a/package-lock.json
+++ b/package-lock.json
@@ -351,6 +351,12 @@
         "through2": "^2.0.3"
       }
     },
+    "@medv/blessed": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@medv/blessed/-/blessed-2.0.1.tgz",
+      "integrity": "sha512-/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -584,6 +590,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/debug": {
       "version": "4.1.5",
@@ -6570,6 +6582,115 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "fx": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/fx/-/fx-18.0.0.tgz",
+      "integrity": "sha512-tzTSHc1IEa8WlEFE7GkGM+/KttpBIudx/PLSPcw74qEYu7npLiKDE8w8RCZK6yaO6ZiJtQZvxLHFqkflcS8eCw==",
+      "dev": true,
+      "requires": {
+        "@medv/blessed": "^2.0.1",
+        "chalk": "^3.0.0",
+        "indent-string": "^4.0.0",
+        "lossless-json": "^1.0.3",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -9742,6 +9863,12 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
+    },
+    "lossless-json": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.3.tgz",
+      "integrity": "sha512-r4w0WrhIHV1lOTVGbTg4Toqwso5x6C8pM7Q/Nto2vy4c7yUSdTYVYlj16uHVX3MT1StpSELDv8yrqGx41MBsDA==",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,6 +383,145 @@
         "fastq": "^1.6.0"
       }
     },
+    "@octokit/auth-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.0.tgz",
+      "integrity": "sha512-eoOVMjILna7FVQf96iWc3+ZtE/ZT6y8ob8ZzcqKY1ibSQCnu4O/B7pJvzMx5cyZ/RjAff6DAdEb0O0Cjcxidkg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0"
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.2.tgz",
+      "integrity": "sha512-ICDcRA0C2vtTZZGud1nXRrBLXZqFayodXAKZfo3dkdcLNqcHsgaz3YSTupbURusYeucSVRjjG+RTcQhx6HPPcg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+      "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.1"
+      }
+    },
+    "@octokit/plugin-request-log": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+      "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
+      "dev": true
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+      "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.1",
+        "deprecation": "^2.3.1"
+      }
+    },
+    "@octokit/request": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.1.tgz",
+      "integrity": "sha512-5/X0AL1ZgoU32fAepTfEoggFinO3rxsMLtzhlUX+RctLrusn/CApJuGFCd0v7GMFhF+8UiCsTTfsu7Fh1HnEJg==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^5.5.0",
+        "@octokit/request-error": "^1.0.1",
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "is-plain-object": "^3.0.0",
+        "node-fetch": "^2.3.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+      "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^2.0.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "@octokit/rest": {
+      "version": "16.43.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz",
+      "integrity": "sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^2.4.0",
+        "@octokit/plugin-paginate-rest": "^1.1.1",
+        "@octokit/plugin-request-log": "^1.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "2.4.0",
+        "@octokit/request": "^5.2.0",
+        "@octokit/request-error": "^1.0.2",
+        "atob-lite": "^2.0.0",
+        "before-after-hook": "^2.0.0",
+        "btoa-lite": "^1.0.0",
+        "deprecation": "^2.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
+        "universal-user-agent": "^4.0.0"
+      }
+    },
+    "@octokit/types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.1.1.tgz",
+      "integrity": "sha512-89LOYH+d/vsbDX785NOfLxTW88GjNd0lWRz1DVPVsZgg9Yett5O+3MOvwo7iHgvUwbFz0mf/yPIjBkUbs4kxoQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": ">= 8"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -704,6 +843,170 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
+    },
+    "action-status": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/action-status/-/action-status-0.1.1.tgz",
+      "integrity": "sha512-EA0TOP32t7B5p3EfE4BytoMT/oAMg+lTWlRzDYRskn8zy9dpVTj0PR6QdUjhBLnez7HdvwNMnh3L3aNOmdAdTw==",
+      "dev": true,
+      "requires": {
+        "@octokit/rest": "^16.15.0",
+        "invariant": "^2.2.4",
+        "require-env": "^0.2.1",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+          "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "dev": true,
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
+        "which-module": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "after": {
       "version": "0.8.2",
@@ -1118,6 +1421,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY=",
       "dev": true
     },
     "autoprefixer": {
@@ -2100,6 +2409,12 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "before-after-hook": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+      "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
+      "dev": true
     },
     "better-assert": {
       "version": "1.0.2",
@@ -3169,6 +3484,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
       "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU=",
+      "dev": true
+    },
+    "btoa-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+      "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
     "buffer": {
@@ -4359,6 +4680,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
     "destroy": {
@@ -9723,6 +10050,24 @@
         }
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -9807,6 +10152,12 @@
       "requires": {
         "lodash._reinterpolate": "^3.0.0"
       }
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
     },
     "log-update": {
       "version": "1.0.2",
@@ -9965,6 +10316,15 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.x"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -10315,6 +10675,31 @@
       "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        },
+        "p-is-promise": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+          "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+          "dev": true
+        }
+      }
     },
     "memoizee": {
       "version": "0.4.14",
@@ -10779,6 +11164,12 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "dev": true
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -11705,6 +12096,12 @@
         "has": "^1.0.3"
       }
     },
+    "octokit-pagination-methods": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/octokit-pagination-methods/-/octokit-pagination-methods-1.1.0.tgz",
+      "integrity": "sha512-fZ4qZdQ2nxJvtcasX7Ghl+WlWS/d9IgnBIwFZXVNNZUmzpno91SX5bc5vuxiuKoCtK78XxGGNuSCrDC7xYB3OQ==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -11864,6 +12261,12 @@
       "dev": true,
       "optional": true
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-event": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-event/-/p-event-1.3.0.tgz",
@@ -11886,6 +12289,24 @@
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
       "dev": true,
       "optional": true
+    },
+    "p-limit": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
     },
     "p-map-series": {
       "version": "1.0.0",
@@ -11919,6 +12340,12 @@
       "requires": {
         "p-finally": "^1.0.0"
       }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -13080,6 +13507,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-env": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/require-env/-/require-env-0.2.1.tgz",
+      "integrity": "sha1-VmNWIc4wk1R9EzyBo2y6vcFDRRQ=",
       "dev": true
     },
     "require-main-filename": {
@@ -16162,6 +16595,15 @@
       "dev": true,
       "requires": {
         "crypto-random-string": "^1.0.0"
+      }
+    },
+    "universal-user-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.0.tgz",
+      "integrity": "sha512-eM8knLpev67iBDizr/YtqkJsF3GK8gzDc6st/WKzrTuPtcsOKW/0IdL4cnMBsU69pOx0otavLWBDGTwg+dB0aA==",
+      "dev": true,
+      "requires": {
+        "os-name": "^3.1.0"
       }
     },
     "universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -281,12 +281,6 @@
         "through2": "^2.0.3"
       }
     },
-    "@medv/blessed": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@medv/blessed/-/blessed-2.0.1.tgz",
-      "integrity": "sha512-/NdX1Ql8hKNM0vHFJnEr/bcw6BG0ULHD3HhInpniZw5ixpl+n/QIRfMEEmLCn7acedbM1zGdZvU5ZMbn9kcF5Q==",
-      "dev": true
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -500,12 +494,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-      "dev": true
     },
     "@types/debug": {
       "version": "4.1.5",
@@ -6725,115 +6713,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "fx": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/fx/-/fx-18.0.1.tgz",
-      "integrity": "sha512-ybeYbpNKPod4z5bcL95Y7AnNFUkFENx6pW/tCqF3HRmXWq5IIydSQbvMJ2TyR/C65UBhJLbUEaiikbZjuXmHUw==",
-      "dev": true,
-      "requires": {
-        "@medv/blessed": "^2.0.1",
-        "chalk": "^3.0.0",
-        "indent-string": "^4.0.0",
-        "lossless-json": "^1.0.3",
-        "string-width": "^4.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-          "dev": true,
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
@@ -10019,12 +9898,6 @@
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
-    },
-    "lossless-json": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-1.0.3.tgz",
-      "integrity": "sha512-r4w0WrhIHV1lOTVGbTg4Toqwso5x6C8pM7Q/Nto2vy4c7yUSdTYVYlj16uHVX3MT1StpSELDv8yrqGx41MBsDA==",
-      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7954,6 +7954,405 @@
         }
       }
     },
+    "gulp-cli": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+      "integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^1.0.1",
+        "archy": "^1.0.0",
+        "array-sort": "^1.0.0",
+        "color-support": "^1.1.3",
+        "concat-stream": "^1.6.0",
+        "copy-props": "^2.0.1",
+        "fancy-log": "^1.3.2",
+        "gulplog": "^1.0.0",
+        "interpret": "^1.1.0",
+        "isobject": "^3.0.1",
+        "liftoff": "^3.1.0",
+        "matchdep": "^2.0.0",
+        "mute-stdout": "^1.0.0",
+        "pretty-hrtime": "^1.0.0",
+        "replace-homedir": "^1.0.0",
+        "semver-greatest-satisfied-range": "^1.1.0",
+        "v8flags": "^3.0.1",
+        "yargs": "^7.1.0"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+          "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+          "dev": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+          "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+          "dev": true
+        },
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+          "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+          "dev": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+              "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+              "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+              "dev": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                  "dev": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+              "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              }
+            },
+            "kind-of": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+              "dev": true
+            }
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+          "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+          "dev": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+              "dev": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+          "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+          "dev": true,
+          "requires": {
+            "detect-file": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "dev": true,
+          "requires": {
+            "kind-of": "^6.0.0"
+          }
+        },
+        "is-descriptor": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "dev": true,
+          "requires": {
+            "is-accessor-descriptor": "^1.0.0",
+            "is-data-descriptor": "^1.0.0",
+            "kind-of": "^6.0.2"
+          }
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "liftoff": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+          "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
+          "dev": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "findup-sync": "^3.0.0",
+            "fined": "^1.0.1",
+            "flagged-respawn": "^1.0.0",
+            "is-plain-object": "^2.0.4",
+            "object.map": "^1.0.0",
+            "rechoir": "^0.6.2",
+            "resolve": "^1.1.7"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "v8flags": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+          "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "yargs": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+          "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+          "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^3.0.0"
+          }
+        }
+      }
+    },
     "gulp-concat": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "scripts": {
     "test": "echo 'WARNING: no tests specified'",
     "build": "gulp build",
-    "prepublish": "./scripts/publish-status  pending \"Publishing ${npm_package_version}...\"",
-    "postpublish": "./scripts/publish-status success \"Published ${npm_package_version}\""
+    "before-publish": "./scripts/publish-status  pending \"Publishing ${npm_package_version}...\"",
+    "after-publish": "./scripts/publish-status success \"Published ${npm_package_version}\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node-sass-import-once": "^1.2.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "echo 'WARNING: no tests specified'",
     "build": "./node_modules/gulp/bin/gulp.js build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "scripts": {
     "test": "echo 'WARNING: no tests specified!'",
-    "build": "gulp build"
+    "build": "gulp build",
+    "export": "gulp export"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,7 @@
   },
   "scripts": {
     "test": "echo 'WARNING: no tests specified'",
-    "build": "gulp build",
-    "before-publish": "./scripts/publish-status  pending \"Publishing ${npm_package_version}...\"",
-    "after-publish": "./scripts/publish-status success \"Published ${npm_package_version}\""
+    "build": "gulp build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sf-design-system",
   "version": "1.2.5",
-  "description": "[![CircleCI](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master.svg?style=shield)](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master) [![Site sf-design-system](https://img.shields.io/badge/site-sf--design--system-blue.svg)](https://sfdigitalservices.github.io/sf-design-system/)",
+  "description": "The San Francisco Digital Services Design System",
   "main": "fractal.js",
   "files": [
     "docs",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",
     "gulp-babel": "^8.0.0",
+    "gulp-cli": "^2.2.0",
     "gulp-concat": "^2.6.1",
     "gulp-if": "^3.0.0",
     "gulp-imagemin": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "babel-core": "^6.26.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
-    "fx": "^18.0.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",
     "gulp-babel": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node-sass-import-once": "^1.2.0"
   },
   "scripts": {
-    "test": "echo '::warn::no tests specified!'",
+    "test": "echo 'WARNING: no tests specified!'",
     "build": "gulp build"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "devDependencies": {
     "@babel/core": "^7.7.2",
     "@frctl/fractal": "^1.2.0",
+    "action-status": "^0.1.1",
     "babel": "^6.23.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -37,7 +38,10 @@
   },
   "scripts": {
     "test": "echo 'WARNING: no tests specified'",
-    "build": "./node_modules/gulp/bin/gulp.js build"
+    "build": "gulp build",
+    "prepublish": "action-status --context=\"publish $npm_package_name\"  --state=pending --desc=\"Publishing ${npm_package_version}...\"",
+    "failpublish": "action-status --context=\"publish $npm_package_name\" --state=error   --desc=\"Failed to publish ${npm_package_version}!\"; exit 1",
+    "postpublish": "action-status --context=\"publish $npm_package_name\" --state=success --desc=\"Publishing ${npm_package_version}...\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.2.5",
   "description": "[![CircleCI](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master.svg?style=shield)](https://circleci.com/gh/SFDigitalServices/sf-design-system/tree/master) [![Site sf-design-system](https://img.shields.io/badge/site-sf--design--system-blue.svg)](https://sfdigitalservices.github.io/sf-design-system/)",
   "main": "fractal.js",
+  "files": [
+    "docs",
+    "public",
+    "src"
+  ],
   "directories": {
     "doc": "docs"
   },

--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
   "scripts": {
     "test": "echo 'WARNING: no tests specified'",
     "build": "gulp build",
-    "prepublish": "action-status --context=\"publish $npm_package_name\"  --state=pending --desc=\"Publishing ${npm_package_version}...\"",
-    "failpublish": "action-status --context=\"publish $npm_package_name\" --state=error   --desc=\"Failed to publish ${npm_package_version}!\"; exit 1",
-    "postpublish": "action-status --context=\"publish $npm_package_name\" --state=success --desc=\"Publishing ${npm_package_version}...\""
+    "prepublish": "./scripts/publish-status  pending \"Publishing ${npm_package_version}...\"",
+    "postpublish": "./scripts/publish-status success \"Published ${npm_package_version}\""
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-core": "^6.26.3",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
+    "fx": "^18.0.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",
     "gulp-babel": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node-sass-import-once": "^1.2.0"
   },
   "scripts": {
-    "test": "echo 'WARNING: no tests specified'",
+    "test": "echo '::warn::no tests specified!'",
     "build": "gulp build"
   },
   "repository": {

--- a/scripts/publish-status
+++ b/scripts/publish-status
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo npx action-status \
+    --context="publish $npm_package_name" \
+    --state="${1:-success}" \
+    --desc="${2:-Published $npm_package_version}" \
+    --url="${3:-https://unpkg.com/$npm_package_name@$npm_package_version/}"

--- a/scripts/publish-status
+++ b/scripts/publish-status
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo npx action-status \
+npx action-status \
     --context="publish $npm_package_name" \
     --state="${1:-success}" \
     --desc="${2:-Published $npm_package_version}" \

--- a/scripts/publish-status
+++ b/scripts/publish-status
@@ -1,6 +1,0 @@
-#!/bin/bash
-npx action-status \
-    --context="publish $npm_package_name" \
-    --state="${1:-success}" \
-    --desc="${2:-Published $npm_package_version}" \
-    --url="${3:-https://unpkg.com/$npm_package_name@$npm_package_version/}"


### PR DESCRIPTION
This adds a new [GitHub Actions workflow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) file, `.github/workflows/ci.yml`, which runs a CI workflow much like Circle but with a new step at the end for publishing to npm.

When this merges every push (with a few exceptions, see below) will be published to npm, which makes changes easier to test in other repos without having to mess with `npm link`. The trick is that versions and [npm tags](https://docs.npmjs.com/cli/dist-tag) map to specific branches:

| branch | version | tag | example |
| :--- | :--- | :--- | :--- |
| `master` | in `package.json` | `latest` (default) | `1.2.0`
| `release-<version>` | `<version>-rc.<sha>` |  `next` | `1.2.1-rc.abacad0`
| all other branches | `0.0.0-<sha>` | `canary` | `0.0.0-abacad0`

Currently we're using the publish action that I built at GitHub: [primer/publish](https://github.com/primer/publish), which dictates these conventions. If we need to do things differently, I've stubbed out a [fork of that project](https://github.com/shawnbot/npm-publish-action) intended to be more generic, but it needs some more work. For now, you can refer to the [primer/publish docs](https://github.com/primer/publish#readme) to understand how things like [status checks](https://github.com/primer/publish#status-checks) work.

This should close PL-25. Includes #44.