### PR TITLE
Light slate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-design-system",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sf-design-system",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "The San Francisco Digital Services Design System",
   "repository": "SFDigitalServices/sf-design-system",
   "author": "SF Digital Services",

--- a/src/components/00-design-tokens/_colors.scss
+++ b/src/components/00-design-tokens/_colors.scss
@@ -1,6 +1,7 @@
 $white: #fff;
 $black: #212123;
 $slate: #1c3e57; // rgb(28, 62, 87)
+$light-slate: #607889;
 $dark-blue: #0c1464;
 $bright-blue: #4f66ee;
 $blue-1: #edf4f7;

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -39,20 +39,8 @@ input[type='search'] {
   -webkit-appearance: none;
 }
 
-::-webkit-input-placeholder { /* Chrome/Opera/Safari */
-  color: rgba($slate, 0.6);
-}
-
-::-moz-placeholder { /* Firefox 19+ */
-  color: rgba($slate, 0.6);
-}
-
-:-ms-input-placeholder { /* IE 10+ */
-  color: rgba($slate, 0.6);
-}
-
-:-moz-placeholder { /* Firefox 18- */
-  color: rgba($slate, 0.6);
+::placeholder {
+  color: $light-slate;
 }
 
 button,

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -276,9 +276,6 @@ legend {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
     user-select: none;
 
     &::after {

--- a/src/components/04-forms/field-types/_form-fields.scss
+++ b/src/components/04-forms/field-types/_form-fields.scss
@@ -27,16 +27,16 @@
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button,
 input::-webkit-calendar-picker-indicator {
-  -webkit-appearance: none;
+  appearance: none;
   margin: 0;
 }
 
 input[type=number] {
-  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
 input[type='search'] {
-  -webkit-appearance: none;
+  appearance: none;
 }
 
 ::placeholder {
@@ -45,16 +45,14 @@ input[type='search'] {
 
 button,
 input[type='submit'] {
-  -webkit-appearance: none;
-  -moz-appearance: none;
+  appearance: none;
 }
 
 input[type='date'],
 input[type='time'] {
   // Fix styling inconsistencies with
   // date and time inputs on iOS
-  -webkit-appearance: textfield;
-  -moz-appearance: textfield;
+  appearance: textfield;
   min-height: 3rem;
 }
 
@@ -344,8 +342,7 @@ $rc-size: 3rem;
   }
 
   input {
-    -webkit-appearance: none;
-    -moz-appearance: none;
+    appearance: none;
     opacity: 0;
     padding: 0;
     margin: 0;
@@ -479,8 +476,7 @@ input[type='submit'] {
 select {
   display: block;
   background-repeat: no-repeat;
-  -moz-appearance: none;
-  -webkit-appearance: none;
+  appearance: none;
   // Background gradient needed for <= IE9
   // See https://www.filamentgroup.com/lab/select-css.html
   background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTgiIGhlaWdodD0iMTEiIHZpZXdCb3g9IjAgMCAxOCAxMSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTguOTYwMDggMTAuNzU1QzguNzk1NzcgMTAuNzU1NiA4LjYzMjk4IDEwLjcyMzYgOC40ODEwOSAxMC42NjFDOC4zMjkyIDEwLjU5ODMgOC4xOTEyMSAxMC41MDYyIDguMDc1MDggMTAuMzlMMC41NzUwNzUgMi44OUMwLjM0MDM1OSAyLjY1NTI4IDAuMjA4NDk2IDIuMzM2OTQgMC4yMDg0OTYgMi4wMDVDMC4yMDg0OTYgMS42NzMwNiAwLjM0MDM1OSAxLjM1NDcxIDAuNTc1MDc1IDEuMTJDMC44MDk3OTIgMC44ODUyOCAxLjEyODE0IDAuNzUzNDE4IDEuNDYwMDggMC43NTM0MThDMS43OTIwMSAwLjc1MzQxOCAyLjExMDM2IDAuODg1MjggMi4zNDUwOCAxLjEyTDguOTYwMDggNy43NEwxNS41NzUxIDEuMTJDMTUuODA5OCAwLjg4NTI4IDE2LjEyODEgMC43NTM0MTggMTYuNDYwMSAwLjc1MzQxOEMxNi43OTIgMC43NTM0MTggMTcuMTEwNCAwLjg4NTI4IDE3LjM0NTEgMS4xMkMxNy41Nzk4IDEuMzU0NzEgMTcuNzExNyAxLjY3MzA2IDE3LjcxMTcgMi4wMDVDMTcuNzExNyAyLjMzNjk0IDE3LjU3OTggMi42NTUyOCAxNy4zNDUxIDIuODlMOS44NDUwOCAxMC4zOUM5LjcyODk0IDEwLjUwNjIgOS41OTA5NSAxMC41OTgzIDkuNDM5MDYgMTAuNjYxQzkuMjg3MTcgMTAuNzIzNiA5LjEyNDM4IDEwLjc1NTYgOC45NjAwOCAxMC43NTVaIiBmaWxsPSIjMUMzRTU3Ii8+Cjwvc3ZnPgo='), linear-gradient(#fff, #fff);

--- a/src/pattern_scaffolding.scss
+++ b/src/pattern_scaffolding.scss
@@ -8,7 +8,6 @@
 @import 'components/00-design-tokens/breakpoints';
 
 #sf-patterns {
-  -webkit-box-sizing: border-box !important;
   box-sizing: border-box !important;
   max-width: 100%;
   padding: 1em;


### PR DESCRIPTION
This adds a `$light-slate` `#607889` SCSS variable. There wasn't a variable for the old 65% slate, but there were some `rgba($slate, .6)` values for text field placeholder color, which I swapped out for the new value. There aren't actually any text fields with placeholders visible in the Fractal site, which is probably good because we've (on Slack, at least) advocated against using them entirely. 😬 

While I was in there I also noticed that the placeholder styles were targeting a bunch of vendor-specific selectors, which [autoprefixer](https://github.com/postcss/autoprefixer/#readme) handles automatically when we style `::placeholder`. I fixed a couple of other vendor-specific selectors like `user-select` and `appearance`, too.

This will release version `1.3.0`.

/cc @laurenajong @nlsfds