### PR TITLE
Stylelint tweaks

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -10,3 +10,4 @@ rules:
     - severity: warning
       ignore:
         - rem
+  property-no-vendor-prefix: true

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -7,6 +7,6 @@ rules:
   no-descending-specificity: null
   plugin/no-unsupported-browser-features:
     - true
-    - severity: warn
+    - severity: warning
       ignore:
         - rem


### PR DESCRIPTION
- Added [property-no-vendor-prefix](https://stylelint.io/user-guide/rules/property-no-vendor-prefix), which should help us avoid adding unnecessary vendor prefixes in the future.
- Fixed the `severity` of the `no-unsupported-browser-features` rule: it's supposed to be "warning", not "warn".

Part of #52 